### PR TITLE
Remove duplicate IMAGE_STORAGE_DIR and IMAGE_LIST_FILE env vars

### DIFF
--- a/Containerfile.v1
+++ b/Containerfile.v1
@@ -11,8 +11,6 @@ ENV IMAGE_LIST_FILE=${IMAGE_STORAGE_DIR}/image-list.txt
 COPY ./embed_image.sh /usr/bin/
 COPY ./copy_embedded_images.sh /usr/bin/
 
-ENV IMAGE_STORAGE_DIR=/usr/lib/containers/storage
-ENV IMAGE_LIST_FILE=${IMAGE_STORAGE_DIR}/image-list.txt
 
 # Pull the container images into /usr/lib/containers/storage:
 # - Each image goes into a separate sub-directory


### PR DESCRIPTION
Removed environment variable definitions for image storage. As there are duplicates and already defined above