### PR TITLE
Fix formatting in build.sh for podman build command extra spaces

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ echo "#### Building a new bootc image with MicroShift and application Container 
 sudo podman build -t "${IMAGE_NAME}:${TAG}" \
     --volume /etc/rhsm:/etc/rhsm:ro,z \
     --volume /etc/pki/entitlement:/etc/pki/entitlement:ro,z \
-    --volume /etc/containers/registries.d/registry-5000.yaml:/etc/containers/registries.d/registry-5000.yaml:ro,z \    
+    --volume /etc/containers/registries.d/registry-5000.yaml:/etc/containers/registries.d/registry-5000.yaml:ro,z \
     --volume /etc/yum.repos.d:/etc/yum.repos.d:ro,z \
     --volume /etc/containers/registries.conf.d/99-mirrors.conf:/etc/containers/registries.conf.d/99-mirrors.conf:ro,z \
     --volume /etc/containers/policy.json:/etc/containers/policy.json:ro,z \


### PR DESCRIPTION
there are extra spaces causing error during build
+ echo '#### Building a new bootc image with MicroShift and application Container images embeeded to it'

#### Building a new bootc image with MicroShift and application Container images embeeded to it

+ sudo podman build -t microshift-bootc-embeeded:4.19 --volume /etc/rhsm:/etc/rhsm:ro,z --volume /etc/pki/entitlement:/etc/pki/entitlement:ro,z --volume /etc/containers/registries.d/registry-5000.yaml:/etc/containers/registries.d/registry-5000.yaml:ro,z ' '

Error: context must be a directory: "/home/lab-user/bootc-embeeded-containers/ "